### PR TITLE
Fix the concurrency groups that cancelled the release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,7 +10,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: codeql-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -10,7 +10,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: container-security-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: security-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
Der v1.2.0-Release hat sich selbst abgebrochen.

Die Gruppe war `${{ github.workflow }}-${{ github.ref }}`. Ein über `workflow_call` aufgerufener Workflow erbt aber beides vom Aufrufer, also landeten ci, security, codeql und container-security beim Release alle in derselben Gruppe. Zwei liefen, die anderen beiden standen dahinter und wurden abgebrochen. Damit fehlten Gates, und `build-release` wurde übersprungen.

Positiv: Es wurde nichts veröffentlicht. Die Gates haben genau das getan, wofür sie da sind.

Jeder Workflow benennt seine Gruppe jetzt selbst, und außerhalb von Pull Requests fällt der Schlüssel auf `github.run_id` zurück, sodass sich nichts mehr anstellen kann. Bei Pull Requests wird weiterhin ein überholter Lauf abgelöst, was der einzige Zweck war.